### PR TITLE
Robust shared frameworks loading

### DIFF
--- a/XcodePostFacto/XcodePostFacto.m
+++ b/XcodePostFacto/XcodePostFacto.m
@@ -78,9 +78,14 @@ static CFURLRef xpf_LSCopyDefaultApplicationURLForURL (CFURLRef inURL, LSRolesMa
     for (size_t i = 0; i < sizeof(sharedFrameworks) / sizeof(sharedFrameworks[0]); i++) {
         NSString *framework = sharedFrameworks[i];
         NSString *path = [[[NSBundle mainBundle] sharedFrameworksPath] stringByAppendingPathComponent: framework];
+        NSBundle *bundle = [NSBundle bundleWithPath: path];
         
-        if (![[NSBundle bundleWithPath: path] loadAndReturnError: &error]) {
-            XPFLog(@"Failed to load %@: %@", framework, error);
+        if (bundle) {
+            if (!([bundle loadAndReturnError: &error])) {
+                XPFLog(@"Failed to load %@: %@", framework, error);
+            }
+        } else {
+            XPFLog(@"Framework %@ not found", framework);
         }
     }
     

--- a/XcodePostFacto/XcodePostFacto.m
+++ b/XcodePostFacto/XcodePostFacto.m
@@ -77,7 +77,7 @@ static CFURLRef xpf_LSCopyDefaultApplicationURLForURL (CFURLRef inURL, LSRolesMa
     XPFLog(@"Initializing Mavericks shared frameworks");
     for (size_t i = 0; i < sizeof(sharedFrameworks) / sizeof(sharedFrameworks[0]); i++) {
         NSString *framework = sharedFrameworks[i];
-        NSString *path = [[[NSBundle mainBundle] sharedFrameworksPath] stringByAppendingPathComponent: framework];
+        NSString *path = [[[NSBundle bundleWithIdentifier: @"com.apple.dt.Xcode"] sharedFrameworksPath] stringByAppendingPathComponent: framework];
         NSBundle *bundle = [NSBundle bundleWithPath: path];
         
         if (bundle) {


### PR DESCRIPTION
When loaded from the ibtoold process, the shared frameworks were not found at the shared frameworks path since the main bundle of ibtoold is not the same as the one from Xcode.

Using the Xcode bundle by its identifier instead of the main bundle ensures that the shared frameworks are always found at the right place.

For some unknown reason, it would even crash while logging the error with the following stack trace:

```
Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   libobjc.A.dylib                 0x00007fff932c2097 objc_msgSend + 23
1   com.apple.Foundation            0x00007fff8b45e7a4 _NSDescriptionWithLocaleFunc + 41
2   com.apple.CoreFoundation        0x00007fff8b8b1ce4 __CFStringAppendFormatCore + 7332
3   com.apple.CoreFoundation        0x00007fff8b8e0263 _CFStringCreateWithFormatAndArgumentsAux + 115
4   com.apple.Foundation            0x00007fff8b45e74f -[NSPlaceholderString initWithFormat:locale:arguments:] + 132
5   com.apple.Foundation            0x00007fff8b461fac +[NSString stringWithFormat:] + 170
6   org.landonf.XcodePostFacto      0x00000001072ba15f +[XcodePostFacto ide_initializeWithOptions:error:] + 319 (XcodePostFacto.m:83)
7   com.apple.dt.IDEFoundation      0x00000001055f99b9 _IDEInitializeOnePlugInAndPrerequisites + 893
8   com.apple.dt.IDEFoundation      0x00000001055f9247 _IDEInitializePlugIns + 1004
9   com.apple.dt.IDEFoundation      0x00000001055f895a IDEInitialize + 4826
10  ibtoold                         0x0000000104c77723 0x104c65000 + 75555
11  ibtoold                         0x0000000104c76696 0x104c65000 + 71318
12  libdyld.dylib                   0x00007fff8afeb5fd start + 1
```
