### PR TITLE
Fix pngcrush crash

### DIFF
--- a/xpf-bootstrap/xpf_bootstrap.mm
+++ b/xpf-bootstrap/xpf_bootstrap.mm
@@ -77,6 +77,9 @@ __attribute__((constructor)) static void xpf_prelaunch_initializer (void) {
     
     /* Use the standard dyld callback for all other rebindings */
     _dyld_register_func_for_add_image(xpf_add_image_callback);
+    
+    /* Ditch the inserted lib to prevent breaking pngcrush */
+    unsetenv("DYLD_INSERT_LIBRARIES");
 }
 
 /**


### PR DESCRIPTION
pngcrush apparently only comes in an i386 slice. xpf-bootstrap, meanwhile, can't be built universal. The result is an `abort()` in dyld when pngcrush is run by the asset catalog compiler. Therefore, just `unsetenv()` to prevent it from being loaded into child processes.
